### PR TITLE
Fix for Using Target Star Class During Refueling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 dist
 *.bat
 *.log
+.vscode
+*.pyc

--- a/dev_autopilot.py
+++ b/dev_autopilot.py
@@ -175,6 +175,8 @@ def ship():
                 
                 if log_event == 'StartJump':
                     ship['status'] = str('starting_'+log['JumpType']).lower()
+                    if log['JumpType'] == 'Hyperspace':
+                        ship['star_class'] = log['StarClass']
                     
                 elif log_event == 'SupercruiseEntry' or log_event == 'FSDJump':
                     ship['status'] = 'in_supercruise'
@@ -226,9 +228,7 @@ def ship():
                 # parse location
                 if (log_event == 'Location' or log_event == 'FSDJump') and 'StarSystem' in log:
                     ship['location'] = log['StarSystem']
-                if 'StarClass' in log:
-                    ship['star_class'] = log['StarClass']
-                    
+
                 # parse target
                 if log_event == 'FSDTarget':
                     if log['Name'] == ship['location']:
@@ -244,7 +244,7 @@ def ship():
             except Exception as e:
                 logging.exception("Exception occurred")
                 print(e)
-#     logging.debug('ship='+str(ship))
+        # logging.debug('ship='+str(ship))
     return ship
 
 


### PR DESCRIPTION
This is working for non-scoopable stars now. Simple fix really. I didn't see any testing files in the repo but I did test on a 300LY route through scoopable and non-scoopable stars with no issues. I had the threshold turned up to a fairly high percentage to see plenty of refuel activity.